### PR TITLE
Add book service tests

### DIFF
--- a/internal/service/domain/book_test.go
+++ b/internal/service/domain/book_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/demirbalemir/hop/Onboardingv2/internal/entities"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // Dummy repo that does nothing (we're testing API logic only)
@@ -48,4 +49,111 @@ func TestSearchGoogleBooks(t *testing.T) {
 	assert.Equal(t, "abc123", results[0].ID)
 	assert.Equal(t, "Harry Potter and the Sorcerer's Stone", results[0].VolumeInfo.Title)
 	assert.Equal(t, "J.K. Rowling", results[0].VolumeInfo.Authors[0])
+}
+
+// repoMock uses testify's mock to verify interactions with the repository.
+type repoMock struct {
+	mock.Mock
+}
+
+func (m *repoMock) FindAll(ctx context.Context) ([]*entities.Book, error) {
+	args := m.Called(ctx)
+	books, _ := args.Get(0).([]*entities.Book)
+	return books, args.Error(1)
+}
+
+func (m *repoMock) FindById(ctx context.Context, id int) (*entities.Book, error) {
+	args := m.Called(ctx, id)
+	book, _ := args.Get(0).(*entities.Book)
+	return book, args.Error(1)
+}
+
+func (m *repoMock) Create(ctx context.Context, book *entities.Book) error {
+	args := m.Called(ctx, book)
+	return args.Error(0)
+}
+
+func (m *repoMock) Update(ctx context.Context, book *entities.Book) error {
+	args := m.Called(ctx, book)
+	return args.Error(0)
+}
+
+func (m *repoMock) Delete(ctx context.Context, id int) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+// helper to create service with mock repository
+func newServiceWithMock(repo *repoMock) *BookService {
+	return &BookService{repo: repo, client: &http.Client{}}
+}
+
+func TestBookService_GetAllBooks(t *testing.T) {
+	ctx := context.Background()
+	expected := []*entities.Book{{ID: 1, Title: "Test"}}
+
+	repo := &repoMock{}
+	repo.On("FindAll", ctx).Return(expected, nil).Once()
+
+	svc := newServiceWithMock(repo)
+
+	books, err := svc.GetAllBooks(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, books)
+	repo.AssertExpectations(t)
+}
+
+func TestBookService_GetBookByID(t *testing.T) {
+	ctx := context.Background()
+	expected := &entities.Book{ID: 2, Title: "Another"}
+
+	repo := &repoMock{}
+	repo.On("FindById", ctx, 2).Return(expected, nil).Once()
+
+	svc := newServiceWithMock(repo)
+
+	book, err := svc.GetBookByID(ctx, 2)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, book)
+	repo.AssertExpectations(t)
+}
+
+func TestBookService_AddBook(t *testing.T) {
+	ctx := context.Background()
+	b := &entities.Book{Title: "Create"}
+
+	repo := &repoMock{}
+	repo.On("Create", ctx, b).Return(nil).Once()
+
+	svc := newServiceWithMock(repo)
+
+	err := svc.AddBook(ctx, b)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestBookService_UpdateBook(t *testing.T) {
+	ctx := context.Background()
+	b := &entities.Book{ID: 3, Title: "Updated"}
+
+	repo := &repoMock{}
+	repo.On("Update", ctx, b).Return(nil).Once()
+
+	svc := newServiceWithMock(repo)
+
+	err := svc.UpdateBook(ctx, b)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestBookService_RemoveBook(t *testing.T) {
+	ctx := context.Background()
+	repo := &repoMock{}
+	repo.On("Delete", ctx, 4).Return(nil).Once()
+
+	svc := newServiceWithMock(repo)
+
+	err := svc.RemoveBook(ctx, 4)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary
- add new repoMock using `testify/mock`
- test all CRUD methods of BookService

## Testing
- `go test ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_68651e183cd88324983376b4f5f3529c