### PR TITLE
Fix baseURL override in book service

### DIFF
--- a/internal/service/domain/book.go
+++ b/internal/service/domain/book.go
@@ -15,6 +15,11 @@ type BookService struct {
 	repo   storage.BookRepository
 	client *http.Client
 }
+
+type contextKey string
+
+const baseURLKey contextKey = "baseURL"
+
 type GoogleBooksSearchResponse struct {
 	Items []entities.GoogleBook `json:"items"`
 }
@@ -53,7 +58,7 @@ func (s *BookService) SearchGoogleBooks(ctx context.Context, title string) ([]en
 	baseURL := "https://www.googleapis.com/books/v1/volumes"
 
 	// Allow override in tests via context
-	if customBaseURL := ctx.Value("baseURLKey"); customBaseURL != nil {
+	if customBaseURL := ctx.Value(baseURLKey); customBaseURL != nil {
 		if str, ok := customBaseURL.(string); ok {
 			baseURL = str
 		}

--- a/internal/service/domain/book_test.go
+++ b/internal/service/domain/book_test.go
@@ -11,10 +11,6 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-type contextKey string
-
-const baseURLKey contextKey = "baseURL"
-
 // Dummy repo that does nothing (we're testing API logic only)
 type mockBookRepo struct{}
 


### PR DESCRIPTION
## Summary
- add context key for injecting baseURL
- use the context key in `SearchGoogleBooks`
- remove duplicate key in `book_test`

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: go.mod requires go >= 1.24.4)*

------
https://chatgpt.com/codex/tasks/task_e_6865232fbe148324ac8b83c28dada71e