### PR TITLE
Fix Google Books search query encoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/demirbalemir/hop/Onboardingv2
 
-go 1.24.4
+go 1.24.3
 
 require (
 	github.com/jackc/pgx/v5 v5.7.5

--- a/internal/service/domain/book.go
+++ b/internal/service/domain/book.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/demirbalemir/hop/Onboardingv2/internal/entities"
@@ -64,9 +65,16 @@ func (s *BookService) SearchGoogleBooks(ctx context.Context, title string) ([]en
 		}
 	}
 
-	url := fmt.Sprintf("%s?q=%s", baseURL, title)
+	// Build URL with proper query escaping
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base url: %w", err)
+	}
+	q := u.Query()
+	q.Set("q", title)
+	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}


### PR DESCRIPTION
## Summary
- ensure query parameters in SearchGoogleBooks are URL encoded
- lower Go module requirement to 1.24.3 to match container version

## Testing
- `go test ./...` *(fails: requires network access to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68652439d98083248fcce91662d26647